### PR TITLE
Adjust to the changes of `yiisoft/rbac` package 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.0",
         "cycle/database": "^2.1",
         "symfony/console": "^5.3|^6.0",
-        "yiisoft/rbac": "dev-master"
+        "yiisoft/rbac": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/AssignmentsStorage.php
+++ b/src/AssignmentsStorage.php
@@ -101,6 +101,7 @@ final class AssignmentsStorage implements AssignmentsStorageInterface
             ->select([new Fragment('1')])
             ->from($this->tableName)
             ->where(['itemName' => $name])
+            ->limit(1)
             ->run()
             ->fetch();
 

--- a/src/AssignmentsStorage.php
+++ b/src/AssignmentsStorage.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Rbac\Cycle;
 
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Table;
 use Yiisoft\Rbac\Assignment;
 use Yiisoft\Rbac\AssignmentsStorageInterface;
@@ -97,7 +98,7 @@ final class AssignmentsStorage implements AssignmentsStorageInterface
     {
         $result = $this
             ->database
-            ->select('1')
+            ->select([new Fragment('1')])
             ->from($this->tableName)
             ->where(['itemName' => $name])
             ->run()

--- a/src/Command/RbacCycleInit.php
+++ b/src/Command/RbacCycleInit.php
@@ -127,7 +127,6 @@ final class RbacCycleInit extends Command
         $schema->string('userId', 128)->nullable(false);
         $schema->setPrimaryKeys(['itemName', 'userId']);
         $schema->integer('createdAt')->nullable(false);
-        $schema->index(['itemName', 'userId']);
 
         $schema->foreignKey(['itemName'])
             ->references($this->config['itemsTable'], ['name'])

--- a/src/Command/RbacCycleInit.php
+++ b/src/Command/RbacCycleInit.php
@@ -123,8 +123,9 @@ final class RbacCycleInit extends Command
         $table = $this->dbal->database()->table($this->config['assignmentsTable']);
         $schema = $table->getSchema();
 
-        $schema->primary('itemName')->string(128);
-        $schema->primary('userId')->string(128);
+        $schema->string('itemName', 128)->nullable(false);
+        $schema->string('userId', 128)->nullable(false);
+        $schema->setPrimaryKeys(['itemName', 'userId']);
         $schema->integer('createdAt')->nullable(false);
         $schema->index(['itemName', 'userId']);
 

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -71,9 +71,6 @@ final class ItemsStorage implements ItemsStorageInterface
         return empty($item) ? null : $this->populateItem($item);
     }
 
-    /**
-     * @inheritDoc
-     */
     public function exists(string $name): bool
     {
         $item = $this->database->select([new Fragment('1')])->from($this->tableName)->where(['name' => $name])->run()->fetch();

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -73,9 +73,16 @@ final class ItemsStorage implements ItemsStorageInterface
 
     public function exists(string $name): bool
     {
-        $item = $this->database->select([new Fragment('1')])->from($this->tableName)->where(['name' => $name])->run()->fetch();
+        $result = $this
+            ->database
+            ->select([new Fragment('1')])
+            ->from($this->tableName)
+            ->where(['name' => $name])
+            ->limit(1)
+            ->run()
+            ->fetch();
 
-        return !empty($item);
+        return $result !== false;
     }
 
     /**
@@ -198,6 +205,7 @@ final class ItemsStorage implements ItemsStorageInterface
             ->select([new Fragment('1')])
             ->from($this->childrenTableName)
             ->where(['parent' => $name])
+            ->limit(1)
             ->run()
             ->fetch();
 

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -73,6 +73,16 @@ final class ItemsStorage implements ItemsStorageInterface
     /**
      * @inheritDoc
      */
+    public function exists(string $name): bool
+    {
+        $item = $this->database->select('1')->from($this->tableName)->where(['name' => $name])->run()->fetch();
+
+        return !empty($item);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function add(Item $item): void
     {
         $time = time();

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -183,7 +183,11 @@ final class ItemsStorage implements ItemsStorageInterface
             ->where(['parent' => $name, 'name' => new Expression('child')])
             ->fetchAll();
 
-        return array_map(fn (array $item): Item => $this->populateItem($item), $children);
+        $keys = array_column($children, 'name');
+        return array_combine(
+            $keys,
+            array_map(fn (array $item): Item => $this->populateItem($item), $children)
+        );
     }
 
     /**

--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Rbac\Cycle;
 use Cycle\Database\DatabaseInterface;
 use Cycle\Database\DatabaseProviderInterface;
 use Cycle\Database\Injection\Expression;
+use Cycle\Database\Injection\Fragment;
 use Cycle\Database\Table;
 use Yiisoft\Rbac\Item;
 use Yiisoft\Rbac\ItemsStorageInterface;
@@ -75,7 +76,7 @@ final class ItemsStorage implements ItemsStorageInterface
      */
     public function exists(string $name): bool
     {
-        $item = $this->database->select('1')->from($this->tableName)->where(['name' => $name])->run()->fetch();
+        $item = $this->database->select([new Fragment('1')])->from($this->tableName)->where(['name' => $name])->run()->fetch();
 
         return !empty($item);
     }
@@ -197,7 +198,7 @@ final class ItemsStorage implements ItemsStorageInterface
     {
         $result = $this
             ->database
-            ->select('1')
+            ->select([new Fragment('1')])
             ->from($this->childrenTableName)
             ->where(['parent' => $name])
             ->run()

--- a/tests/ItemsStorageTest.php
+++ b/tests/ItemsStorageTest.php
@@ -35,6 +35,28 @@ class ItemsStorageTest extends TestCase
         $this->assertSame('Parent 3', $item->getName());
     }
 
+    public function existsProvider(): array
+    {
+        return [
+            ['Parent 1', true],
+            ['Parent 2', true],
+            ['Parent 3', true],
+            ['Parent 100', false],
+            ['Child 1', true],
+            ['Child 2', true],
+            ['Child 100', false],
+        ];
+    }
+
+    /**
+     * @dataProvider existsProvider
+     */
+    public function testExists(string $name, bool $exists): void
+    {
+        $storage = $this->getStorage();
+        $this->assertSame($storage->exists($name), $exists);
+    }
+
     public function testGetPermission(): void
     {
         $storage = $this->getStorage();

--- a/tests/ItemsStorageTest.php
+++ b/tests/ItemsStorageTest.php
@@ -72,7 +72,11 @@ class ItemsStorageTest extends TestCase
 
         $storage->addChild('Parent 2', 'Child 1');
 
-        $this->assertCount(2, $storage->getChildren('Parent 2'));
+        $children = $storage->getChildren('Parent 2');
+        $this->assertCount(2, $children);
+        foreach ($children as $name => $item) {
+            $this->assertSame($name, $item->getName());
+        }
     }
 
     public function testClear(): void

--- a/tests/ItemsStorageTest.php
+++ b/tests/ItemsStorageTest.php
@@ -82,7 +82,7 @@ class ItemsStorageTest extends TestCase
     public function testClear(): void
     {
         $storage = $this->getStorage();
-        $storage->clear();
+        $this->clear();
 
         $this->assertEmpty($storage->getAll());
         $this->assertEmpty($storage->getChildren('Parent 2'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |

## Summaries

* Fix primary keys of assignments table
* Implement the `exists` method of `ItemsStorageInterface` for `ItemsStorage`.
* Bump yiisoft/rbac to `^1.0`.
* Fix `ItemsStorage::getChildren` to follow the return type `array<string,Item>`.
* Fix the compatibility and test case for MySQL and PostgreSQL: replace `select('1')` with `select([new Fragment('1')])`  to avoid the *unknown column '1' in the 'field list'* error.

### RbacCycleInit command

The `RbacCycleInit` command failed to generate the assignments table,

```sql
SQLSTATE[42000]: Syntax error or access violation: 1063 Incorrect column specifier for column 'itemName'

Creating `auth_assignment` table...
 > SELECT COUNT(*) FROM `information_schema`.`tables` WHERE `table_schema` = 'newtab' AND `table_name` = 'auth_assignment'
 ! CREATE TABLE `auth_assignment` (
    `itemName` varchar (128) NOT NULL AUTO_INCREMENT,
    `userId` varchar (128) NOT NULL AUTO_INCREMENT,
    `createdAt` int (11) NOT NULL,
    CONSTRAINT `auth_assignment_foreign_itemname_630d84f623952` FOREIGN KEY (`itemName`) REFERENCES `auth_item` (`name`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE InnoDB
 ! SQLSTATE[42000]: Syntax error or access violation: 1063 Incorrect column specifier for column 'itemName'
```

The patch's SQL as follows.

```sql
Creating `auth_assignment` table...
 > SELECT COUNT(*) FROM `information_schema`.`tables` WHERE `table_schema` = 'newtab' AND `table_name` = 'auth_assignment'
 > CREATE TABLE `auth_assignment` (
    `itemName` varchar (128) NOT NULL,
    `userId` varchar (128) NOT NULL,
    `createdAt` int (11) NOT NULL,
    PRIMARY KEY (`itemName`, `userId`),
    CONSTRAINT `auth_assignment_foreign_itemname_630d898cbe79a` FOREIGN KEY (`itemName`) REFERENCES `auth_item` (`name`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE InnoDB
 > CREATE INDEX `auth_assignment_index_itemname_userid_630d898cbe793` ON `auth_assignment` (`itemName`, `userId`)
 > CREATE INDEX `auth_assignment_index_itemname_630d898cbe7a2` ON `auth_assignment` (`itemName`)
Table `auth_assignment` created successfully
```



