### PR TITLE
Fix the `AssignmentsStorage::getByUserId` method and add unit tests

### DIFF
--- a/src/AssignmentsStorage.php
+++ b/src/AssignmentsStorage.php
@@ -53,9 +53,12 @@ final class AssignmentsStorage implements AssignmentsStorageInterface
     {
         $assignments = $this->database->select()->from($this->tableName)->where(['userId' => $userId])->fetchAll();
 
-        return array_map(
-            static fn (array $item) => new Assignment($userId, $item['itemName'], (int)$item['createdAt']),
-            $assignments
+        return array_combine(
+            array_column($assignments, 'itemName'),
+            array_map(
+                static fn (array $item) => new Assignment($userId, $item['itemName'], (int)$item['createdAt']),
+                $assignments
+            )
         );
     }
 

--- a/tests/AssignmentsStorageTest.php
+++ b/tests/AssignmentsStorageTest.php
@@ -31,6 +31,11 @@ class AssignmentsStorageTest extends TestCase
         $all = $storage->getAll();
 
         $this->assertCount(2, $all);
+        foreach ($all as $assignments) {
+            foreach ($assignments as $name => $assignment) {
+                $this->assertSame($name, $assignment->getItemName());
+            }
+        }
     }
 
     public function testRemoveByItemName(): void
@@ -47,7 +52,10 @@ class AssignmentsStorageTest extends TestCase
         $assignments = $storage->getByUserId('admin');
 
         $this->assertCount(1, $assignments);
-        $this->assertSame('Admin', $assignments[0]->getItemName());
+        $this->assertSame('Admin', $assignments['Admin']->getItemName());
+        foreach ($assignments as $name => $assignment) {
+            $this->assertSame($name, $assignment->getItemName());
+        }
     }
 
     public function testRemoveByUserId(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Correct the `getByUserId` method to respect the return type `array<string, Assignment>`.
