### PR TITLE
Fix ItemsStorage::getParents and add more unit tests

### DIFF
--- a/src/ItemsStorage.php
+++ b/src/ItemsStorage.php
@@ -174,7 +174,14 @@ final class ItemsStorage implements ItemsStorageInterface
             ->from([$this->tableName, $this->childrenTableName])
             ->where(['child' => $name, 'name' => new Expression('parent')])
             ->fetchAll();
-        return array_map(fn (array $item): Item => $this->populateItem($item), $parents);
+
+        return array_combine(
+            array_column($parents, 'name'),
+            array_map(
+                fn (array $item): Item => $this->populateItem($item),
+                $parents
+            ),
+        );
     }
 
     /**

--- a/tests/AssignmentsStorageTest.php
+++ b/tests/AssignmentsStorageTest.php
@@ -22,6 +22,7 @@ class AssignmentsStorageTest extends TestCase
         $storage = $this->getStorage();
         $storage->renameItem('Admin', 'Tech Admin');
 
+        $this->assertFalse($storage->hasItem('Admin'));
         $this->assertTrue($storage->hasItem('Tech Admin'));
     }
 
@@ -31,8 +32,9 @@ class AssignmentsStorageTest extends TestCase
         $all = $storage->getAll();
 
         $this->assertCount(2, $all);
-        foreach ($all as $assignments) {
+        foreach ($all as $userId => $assignments) {
             foreach ($assignments as $name => $assignment) {
+                $this->assertSame($userId, $assignment->getUserId());
                 $this->assertSame($name, $assignment->getItemName());
             }
         }

--- a/tests/ItemsStorageTest.php
+++ b/tests/ItemsStorageTest.php
@@ -124,13 +124,27 @@ class ItemsStorageTest extends TestCase
         $this->assertEmpty($storage->get('Parent 3'));
     }
 
-    public function testGetParents(): void
+    public function getParentsProvider(): array
+    {
+        return [
+            ['Child 1', ['Parent 1']],
+            ['Child 2', ['Parent 2']],
+        ];
+    }
+
+    /**
+     * @dataProvider getParentsProvider
+     */
+    public function testGetParents(string $childName, array $expectedParents): void
     {
         $storage = $this->getStorage();
-        $parents = $storage->getParents('Child 1');
+        $parents = $storage->getParents($childName);
 
-        $this->assertCount(1, $parents);
-        $this->assertSame('Parent 1', $parents[0]->getName());
+        $this->assertCount(count($expectedParents), $parents);
+        foreach ($parents as $parentName => $parent) {
+            $this->assertContains($parentName, $expectedParents);
+            $this->assertSame($parentName, $parent->getName());
+        }
     }
 
     public function testRemoveChildren(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Fix `ItemsStorage::getParents` method to respect the return type `array<string,Item>`.