### PR TITLE
--force not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Yii RBAC Cycle Database Storage Change Log
 
 ## 1.0.1 under development
-
+- Bug : rbac/cycle/init with --force flag not working 
 - Fix #42: Use integer type instead of timestamp (@arogachev)
 
 ## 1.0.0 March 10, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Yii RBAC Cycle Database Storage Change Log
 
 ## 1.0.1 under development
-- Bug : rbac/cycle/init with --force flag not working 
+
+- Bug #43: Fix not working `--force` flag for `RbacCycleInit` console command.
 - Fix #42: Use integer type instead of timestamp (@arogachev)
 
 ## 1.0.0 March 10, 2023

--- a/src/Command/RbacCycleInit.php
+++ b/src/Command/RbacCycleInit.php
@@ -83,7 +83,7 @@ final class RbacCycleInit extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $force = filter_var($input->getOption('force') ?? true, FILTER_VALIDATE_BOOLEAN);
+        $force = $input->getOption('force') ?? true;
         if ($force) {
             $this->dropTable($this->itemsChildrenTable, $output);
             $this->dropTable($this->assignmentsTable, $output);

--- a/src/Command/RbacCycleInit.php
+++ b/src/Command/RbacCycleInit.php
@@ -83,7 +83,7 @@ final class RbacCycleInit extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $force = $input->getOption('force') ?? true;
+        $force = (bool)($input->getOption('force') ?? true);
         if ($force) {
             $this->dropTable($this->itemsChildrenTable, $output);
             $this->dropTable($this->assignmentsTable, $output);

--- a/src/Command/RbacCycleInit.php
+++ b/src/Command/RbacCycleInit.php
@@ -83,7 +83,7 @@ final class RbacCycleInit extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $force = $input->getOption('force') === true;
+        $force = $input->hasOption('force');
         if ($force === true) {
             $this->dropTable($this->itemsChildrenTable, $output);
             $this->dropTable($this->assignmentsTable, $output);

--- a/src/Command/RbacCycleInit.php
+++ b/src/Command/RbacCycleInit.php
@@ -83,8 +83,8 @@ final class RbacCycleInit extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $force = $input->hasOption('force');
-        if ($force === true) {
+        $force = filter_var($input->getOption('force') ?? true, FILTER_VALIDATE_BOOLEAN);
+        if ($force) {
             $this->dropTable($this->itemsChildrenTable, $output);
             $this->dropTable($this->assignmentsTable, $output);
             $this->dropTable($this->itemsTable, $output);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

`php console rbac/cycle/init --force`
This does not work. Because getOption returns null if the option has no value.
Also, this method returns string and cannot be compared with a boolean value.
