### PR TITLE
Decrease size for string columns from 128 to 126 for PostgreSQL optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Enh #82: Use migrations (@arogachev)
 - Enh #72: Remove duplicate code in `ItemsStorage::add()` (@arogachev)
 - Enh #77: Use snake case for item attribute names (ease migration from Yii 2) (@arogachev)
+- Enh #?: Decrease size for string columns from 128 to 126 for PostgreSQL optimization (@arogachev)
 
 ## 2.0.0 April 20, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Enh #82: Use migrations (@arogachev)
 - Enh #72: Remove duplicate code in `ItemsStorage::add()` (@arogachev)
 - Enh #77: Use snake case for item attribute names (ease migration from Yii 2) (@arogachev)
-- Enh #?: Decrease size for string columns from 128 to 126 for PostgreSQL optimization (@arogachev)
+- Enh #94: Decrease size for string columns from 128 to 126 for PostgreSQL optimization (@arogachev)
 
 ## 2.0.0 April 20, 2023
 

--- a/migrations/assignments/20240103.141900_M_CreateAssignmentsTable.php
+++ b/migrations/assignments/20240103.141900_M_CreateAssignmentsTable.php
@@ -26,8 +26,8 @@ final class CreateAssignmentsTable extends Migration
         $table = $this->database()->table(self::ASSIGNMENTS_TABLE);
         $schema = $table->getSchema();
 
-        $schema->string('item_name', 128)->nullable(false);
-        $schema->string('user_id', 128)->nullable(false);
+        $schema->string('item_name', 126)->nullable(false);
+        $schema->string('user_id', 126)->nullable(false);
         $schema->setPrimaryKeys(['item_name', 'user_id']);
         $schema->integer('created_at')->nullable(false);
 

--- a/migrations/items/20240103.141900_M_CreateItemsTables.php
+++ b/migrations/items/20240103.141900_M_CreateItemsTables.php
@@ -29,7 +29,7 @@ final class CreateItemsTables extends Migration
         $table = $this->database()->table(self::ITEMS_TABLE);
         $schema = $table->getSchema();
 
-        $schema->string('name', 128)->nullable(false);
+        $schema->string('name', 126)->nullable(false);
         $schema->string('type', 10)->nullable(false);
         $schema->string('description', 191);
         $schema->string('rule_name', 64);
@@ -47,8 +47,8 @@ final class CreateItemsTables extends Migration
         $table = $this->database()->table(self::ITEMS_CHILDREN_TABLE);
         $schema = $table->getSchema();
 
-        $schema->string('parent', 128)->nullable(false);
-        $schema->string('child', 128)->nullable(false);
+        $schema->string('parent', 126)->nullable(false);
+        $schema->string('child', 126)->nullable(false);
         $schema->setPrimaryKeys(['parent', 'child']);
 
         $schema

--- a/tests/Base/SchemaTrait.php
+++ b/tests/Base/SchemaTrait.php
@@ -49,13 +49,13 @@ trait SchemaTrait
         $this->assertArrayHasKey('item_name', $columns);
         $itemName = $columns['item_name'];
         $this->assertSame('string', $itemName->getType());
-        $this->assertSame(128, $itemName->getSize());
+        $this->assertSame(126, $itemName->getSize());
         $this->assertFalse($itemName->isNullable());
 
         $this->assertArrayHasKey('user_id', $columns);
         $userId = $columns['user_id'];
         $this->assertSame('string', $userId->getType());
-        $this->assertSame(128, $userId->getSize());
+        $this->assertSame(126, $userId->getSize());
         $this->assertFalse($userId->isNullable());
 
         $this->assertArrayHasKey('created_at', $columns);
@@ -79,13 +79,13 @@ trait SchemaTrait
         $this->assertArrayHasKey('parent', $columns);
         $parent = $columns['parent'];
         $this->assertSame('string', $parent->getType());
-        $this->assertSame(128, $parent->getSize());
+        $this->assertSame(126, $parent->getSize());
         $this->assertFalse($parent->isNullable());
 
         $this->assertArrayHasKey('child', $columns);
         $child = $columns['child'];
         $this->assertSame('string', $child->getType());
-        $this->assertSame(128, $child->getSize());
+        $this->assertSame(126, $child->getSize());
         $this->assertFalse($child->isNullable());
 
         $this->assertSame(['parent', 'child'], $table->getPrimaryKeys());
@@ -134,7 +134,7 @@ trait SchemaTrait
         $this->assertArrayHasKey('name', $columns);
         $name = $columns['name'];
         $this->assertSame('string', $name->getType());
-        $this->assertSame(128, $name->getSize());
+        $this->assertSame(126, $name->getSize());
         $this->assertFalse($name->isNullable());
 
         $this->assertArrayHasKey('type', $columns);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

Related - https://github.com/yiisoft/rbac-db/issues/45.
