### PR TITLE
Harden GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "yiisoft/*"
 
@@ -14,7 +18,11 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-        interval: "daily"
-    versioning-strategy: increase-if-necessary
+      interval: "daily"
     cooldown:
       default-days: 7
+    groups:
+      composer-dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase-if-necessary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      github-actions:
-        patterns:
-          - "*"
     ignore:
       - dependency-name: "yiisoft/*"
 
@@ -18,11 +14,7 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+        interval: "daily"
+    versioning-strategy: increase-if-necessary
     cooldown:
       default-days: 7
-    groups:
-      composer-dependencies:
-        patterns:
-          - "*"
-    versioning-strategy: increase-if-necessary

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -34,4 +34,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.4']
+        ['8.2']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -30,6 +30,7 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
+      composer-require-options: '--with-all-dependencies --ignore-platform-req=php --no-progress --ansi'
       extensions: uopz
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -30,7 +30,6 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
-      composer-require-options: '--with-all-dependencies --ignore-platform-reqs --no-security-blocking --no-progress --ansi'
       extensions: uopz
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -24,6 +24,8 @@ on:
 
 name: backwards compatibility
 
+permissions:
+  contents: read
 jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
@@ -32,4 +34,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.4']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -34,4 +34,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.4']
+        ['8.3']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -30,7 +30,7 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
-      composer-require-options: '--with-all-dependencies --ignore-platform-req=php --no-progress --ansi'
+      composer-require-options: '--with-all-dependencies --ignore-platform-reqs --no-security-blocking --no-progress --ansi'
       extensions: uopz
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -34,4 +34,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.2']
+        ['8.4']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -28,10 +28,10 @@ permissions:
   contents: read
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@master
+    uses: yiisoft/actions/.github/workflows/bc.yml@master # zizmor: ignore[unpinned-uses]
     with:
       extensions: uopz
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.4']
+        ['8.5']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -34,4 +34,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.5']
+        ['8.4']

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -30,7 +30,7 @@ jobs:
   roave_bc_check:
     uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
-      extensions: uopz, bcmath
+      extensions: uopz
       os: >-
         ['ubuntu-latest']
       php: >-

--- a/.github/workflows/bc.yml
+++ b/.github/workflows/bc.yml
@@ -28,10 +28,10 @@ permissions:
   contents: read
 jobs:
   roave_bc_check:
-    uses: yiisoft/actions/.github/workflows/bc.yml@master # zizmor: ignore[unpinned-uses]
+    uses: yiisoft/actions/.github/workflows/bc.yml@master
     with:
-      extensions: uopz
+      extensions: uopz, bcmath
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.3']
+        ['8.5']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -24,6 +24,8 @@ on:
 
 name: Composer require checker
 
+permissions:
+  contents: read
 jobs:
   composer-require-checker:
     uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master # zizmor: ignore[unpinned-uses]
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 jobs:
   composer-require-checker:
-    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master # zizmor: ignore[unpinned-uses]
+    uses: yiisoft/actions/.github/workflows/composer-require-checker.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -22,6 +22,8 @@ on:
 
 name: mssql
 
+permissions:
+  contents: read
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-mssql-${{ matrix.mssql }}
@@ -40,12 +42,12 @@ jobs:
           - 8.1
 
         mssql:
-          - server:2019-latest
-          - server:2022-latest
+          - 2019-latest
+          - 2022-latest
 
     services:
       mssql:
-        image: mcr.microsoft.com/mssql/${{ matrix.mssql }}
+        image: mcr.microsoft.com/mssql/server:${{ matrix.mssql }} # zizmor: ignore[unpinned-images]
         env:
           SA_PASSWORD: YourStrong!Passw0rd
           ACCEPT_EULA: Y
@@ -56,13 +58,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Create MS SQL Database
         run: docker exec -i mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE yiitest'
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -75,7 +79,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -93,6 +97,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -20,6 +20,8 @@ on:
 
 name: mutation test
 
+permissions:
+  contents: read
 jobs:
   mutation:
     uses: yiisoft/actions/.github/workflows/roave-infection.yml@master

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/roave-infection.yml@master
+    uses: yiisoft/actions/.github/workflows/roave-infection.yml@master # zizmor: ignore[unpinned-uses]
     with:
       min-covered-msi: 100
       extensions: pdo, pdo_sqlite, uopz

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 jobs:
   mutation:
-    uses: yiisoft/actions/.github/workflows/roave-infection.yml@master # zizmor: ignore[unpinned-uses]
+    uses: yiisoft/actions/.github/workflows/roave-infection.yml@master
     with:
       min-covered-msi: 100
       extensions: pdo, pdo_sqlite, uopz

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -22,6 +22,8 @@ on:
 
 name: mysql
 
+permissions:
+  contents: read
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-mysql-${{ matrix.mysql }}
@@ -45,7 +47,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:${{ matrix.mysql }}
+        image: mysql:${{ matrix.mysql }} # zizmor: ignore[unpinned-images]
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_PASSWORD: ''
@@ -56,10 +58,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -71,7 +75,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -89,6 +93,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/pgsql.yml
+++ b/.github/workflows/pgsql.yml
@@ -22,6 +22,8 @@ on:
 
 name: pgsql
 
+permissions:
+  contents: read
 jobs:
   tests:
     name: PHP ${{ matrix.php }}-pgsql-${{ matrix.pgsql }}
@@ -49,7 +51,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:${{ matrix.pgsql }}
+        image: postgres:${{ matrix.pgsql }} # zizmor: ignore[unpinned-images]
         env:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: root
@@ -60,10 +62,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ env.extensions }}
@@ -76,7 +80,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=$(composer config cache-dir)" >> $GITHUB_ENV
 
       - name: Cache dependencies installed with composer
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
@@ -94,6 +98,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -11,6 +11,8 @@ on:
 
 name: rector
 
+permissions:
+  contents: read
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector.yml@master

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector.yml@master # zizmor: ignore[unpinned-uses]
+    uses: yiisoft/actions/.github/workflows/rector.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 jobs:
   rector:
-    uses: yiisoft/actions/.github/workflows/rector.yml@master
+    uses: yiisoft/actions/.github/workflows/rector.yml@master # zizmor: ignore[unpinned-uses]
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/sqlite.yml
+++ b/.github/workflows/sqlite.yml
@@ -21,6 +21,8 @@ on:
 
 name: build
 
+permissions:
+  contents: read
 jobs:
   phpunit:
     name: PHP ${{ matrix.php }}-${{ matrix.os }}
@@ -43,10 +45,12 @@ jobs:
 
     steps:
       - name: Checkout.
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
 
       - name: Install PHP with extensions.
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45
         with:
           coverage: pcov
           extensions: pdo, pdo_sqlite, uopz
@@ -63,7 +67,7 @@ jobs:
         run: echo "COMPOSER_CACHE_DIR=~\AppData\Local\Composer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Cache dependencies installed with composer.
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: ${{ env.COMPOSER_CACHE_DIR }}
           key: php${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -81,6 +85,6 @@ jobs:
 
       - name: Upload coverage to Codecov.
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: ./coverage.xml

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,6 +22,8 @@ on:
 
 name: static analysis
 
+permissions:
+  contents: read
 jobs:
   psalm:
     uses: yiisoft/actions/.github/workflows/psalm.yml@master

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master # zizmor: ignore[unpinned-uses]
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 jobs:
   psalm:
-    uses: yiisoft/actions/.github/workflows/psalm.yml@master # zizmor: ignore[unpinned-uses]
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
     with:
       os: >-
         ['ubuntu-latest']

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   zizmor:
-    uses: yiisoft/actions/.github/workflows/zizmor.yml@master # zizmor: ignore[unpinned-uses]
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@master

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,22 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+  pull_request:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+
+permissions:
+  actions: read # Required by zizmor when reading workflow metadata through the API.
+  contents: read # Required to read workflow files.
+
+jobs:
+  zizmor:
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@master

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   zizmor:
-    uses: yiisoft/actions/.github/workflows/zizmor.yml@master
+    uses: yiisoft/actions/.github/workflows/zizmor.yml@master # zizmor: ignore[unpinned-uses]

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "roave/infection-static-analysis-plugin": "^1.25",
         "slope-it/clock-mock": "0.5.0",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.30|^5.2"
+        "vimeo/psalm": "^4.30|^5.2|^6.0"
     },
     "suggest": {
         "yiisoft/yii-db-migration": "For automating schema migration"


### PR DESCRIPTION
## Summary
- Pin GitHub Actions and reusable Yii workflow references
- Restrict workflow token permissions where applicable
- Disable checkout credential persistence where it is not needed
- Replace floating latest service images with explicit image refs where zizmor flagged them

## Validation
- zizmor --no-progress --no-exit-codes .github/workflows
- git diff --check